### PR TITLE
fix typos

### DIFF
--- a/README
+++ b/README
@@ -17,8 +17,6 @@ DESCRIPTION
     changes will not be made without extreme consideration.
 
 SYNOPSIS
-    The synopsis is split into three parts: The first two are for model
-    developers, and the last is for the developer using the models.
 
       package MyApp::Model::User;
       use Mad::Mapper -base;

--- a/README
+++ b/README
@@ -5,19 +5,19 @@ VERSION
     0.07
 
 DESCRIPTION
-    Mad::Mapper is base class for objects that should be stored to the a
+    Mad::Mapper is a base class for objects that should be stored in a
     persistent SQL database. Currently the supported backends are Mojo::Pg
     Mojo::mysql and Mojo::SQLite. These backends need to be installed
     separately.
 
       $ cpanm Mad::Mapper
-      $ cpanm Mojo::Pg # Mad::Mapper now support postgres!
+      $ cpanm Mojo::Pg # Mad::Mapper now supports postgres!
 
     THIS MODULE IS EXPERIMENTAL. It is in use in production though, so big
     changes will not be made without extreme consideration.
 
 SYNOPSIS
-    The synopsis is split into three parts: The two first is for model
+    The synopsis is split into three parts: The first two are for model
     developers, and the last is for the developer using the models.
 
       package MyApp::Model::User;
@@ -88,7 +88,7 @@ METHODS
 
     *   %t
 
-        Will be replaced by </table>. Example: "SELECT * FROM %t" becomes
+        Will be replaced by "table". Example: "SELECT * FROM %t" becomes
         "SELECT * FROM users".
 
     *   %c
@@ -111,7 +111,7 @@ METHODS
 
         Becomes a literal "%c".
 
-    It is also possible to defined aliases for "%t", "%c", "%c=" and "%pc".
+    It is also possible to define aliases for "%t", "%c", "%c=" and "%pc".
     Example:
 
       %t.x = some_table as x
@@ -151,7 +151,7 @@ METHODS
     is given as argument. See "SYNOPSIS" for example.
 
 COPYRIGHT AND LICENSE
-    Copyright (C) 2014, Jan Henning Thorsen
+    Copyright (C) 2014-2016, Jan Henning Thorsen
 
     This program is free software, you can redistribute it and/or modify it
     under the terms of the Artistic License version 2.0.

--- a/lib/Mad/Mapper.pm
+++ b/lib/Mad/Mapper.pm
@@ -12,20 +12,20 @@ Mad::Mapper - Map Perl objects to PostgreSQL, MySQL or SQLite data
 
 =head1 DESCRIPTION
 
-L<Mad::Mapper> is base class for objects that should be stored to the a
+L<Mad::Mapper> is a base class for objects that should be stored in a
 persistent SQL database. Currently the supported backends are L<Mojo::Pg>
 L<Mojo::mysql> and L<Mojo::SQLite>. These backends need to be installed
 separately.
 
   $ cpanm Mad::Mapper
-  $ cpanm Mojo::Pg # Mad::Mapper now support postgres!
+  $ cpanm Mojo::Pg # Mad::Mapper now supports postgres!
 
 THIS MODULE IS EXPERIMENTAL. It is in use in production though, so
 big changes will not be made without extreme consideration.
 
 =head1 SYNOPSIS
 
-The synopsis is split into three parts: The two first is for model developers,
+The synopsis is split into three parts: The first two are for model developers,
 and the last is for the developer using the models.
 
   package MyApp::Model::User;
@@ -126,7 +126,7 @@ Used to expand a given C<$sst> with variables defined by helpers.
 
 =item * %t
 
-Will be replaced by </table>. Example: "SELECT * FROM %t" becomes "SELECT * FROM users".
+Will be replaced by L</table>. Example: "SELECT * FROM %t" becomes "SELECT * FROM users".
 
 =item * %c
 
@@ -150,7 +150,7 @@ Becomes a literal "%c".
 
 =back
 
-It is also possible to defined aliases for "%t", "%c", "%c=" and "%pc". Example:
+It is also possible to define aliases for "%t", "%c", "%c=" and "%pc". Example:
 
   %t.x = some_table as x
   %c.x = x.col1
@@ -498,7 +498,7 @@ sub TO_JSON {
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2014, Jan Henning Thorsen
+Copyright (C) 2014-2016, Jan Henning Thorsen
 
 This program is free software, you can redistribute it and/or modify it under
 the terms of the Artistic License version 2.0.

--- a/lib/Mad/Mapper.pm
+++ b/lib/Mad/Mapper.pm
@@ -25,9 +25,6 @@ big changes will not be made without extreme consideration.
 
 =head1 SYNOPSIS
 
-The synopsis is split into three parts: The first two are for model developers,
-and the last is for the developer using the models.
-
   package MyApp::Model::User;
   use Mad::Mapper -base;
 

--- a/lib/Mad/Mapper/Guides/Custom.pod
+++ b/lib/Mad/Mapper/Guides/Custom.pod
@@ -14,7 +14,7 @@ It is possible to override the private methods C<_find_sst()>,
 C<_insert_sst()>, C<_update_sst()> and C<_delete_sst()> for more
 control. The benefit of overriding these methods is if you want
 to use optional columns for doing queries. The example below can
-find a row base on both the "id" and "email" column.
+find a row based on both the "id" and "email" column.
 
   sub _find_sst {
     my $self = shift;
@@ -30,8 +30,8 @@ find a row base on both the "id" and "email" column.
 =head2 Full control
 
 Instead of using the automatic generated methods from simple SQL statements,
-it is possible to do the complete query yourself. Below is the example of how
-a completely custom C<_insert()>:
+it is possible to do the complete query yourself. Below is an example of a
+completely custom C<_insert()>:
 
   package MyApp::Model::User;
   use Mad::Mapper -base;
@@ -58,7 +58,7 @@ You can also override C<_find()>, C<_update()> and C<_delete()>.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2014, Jan Henning Thorsen
+Copyright (C) 2014-2016, Jan Henning Thorsen
 
 This program is free software, you can redistribute it and/or modify it under
 the terms of the Artistic License version 2.0.

--- a/lib/Mad/Mapper/Guides/HasMany.pod
+++ b/lib/Mad/Mapper/Guides/HasMany.pod
@@ -75,14 +75,14 @@ You can define your own query:
     );
   }
 
-Note above that C<@extra> is the any extra arguments passed on to
+Note above that C<@extra> is any extra arguments passed on to
 the method:
 
   $user->groups_sorted("extra", "args");
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2014, Jan Henning Thorsen
+Copyright (C) 2014-2016, Jan Henning Thorsen
 
 This program is free software, you can redistribute it and/or modify it under
 the terms of the Artistic License version 2.0.

--- a/lib/Mad/Mapper/Guides/Tutorial.pod
+++ b/lib/Mad/Mapper/Guides/Tutorial.pod
@@ -12,7 +12,7 @@ your application.
 =head2 Create a model
 
 The snippet below is enough to define a model. A model should contain all
-the columns that you want to map to your table. Is many cases you don't
+the columns that you want to map to your table. In many cases you don't
 need to define a L<table|Mad::Mapper/table>, since it is automatically
 created from the last part of the package name.
 
@@ -22,7 +22,7 @@ created from the last part of the package name.
   # import all the helpers from Mad::Mapper
   use Mad::Mapper -base;
 
-  # columns becomes accessors, just like you would define with "has"
+  # columns become accessors, just like you would define with "has"
   col id => undef;
   col email => '';
 
@@ -30,7 +30,7 @@ See also L<Mad::Mapper::Guides::Custom> if you want more control.
 
 =head2 Application code
 
-The code below show how you can use the models in a L<Mojolicious::Lite>
+The code below shows how you can use the models in a L<Mojolicious::Lite>
 application. The example connects to postrgres using L<Mojo::Pg>, but you
 can also use L<Mojo::SQLite> or L<Mojo::mysql>.
 
@@ -89,7 +89,7 @@ can also use L<Mojo::SQLite> or L<Mojo::mysql>.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2014, Jan Henning Thorsen
+Copyright (C) 2014-2016, Jan Henning Thorsen
 
 This program is free software, you can redistribute it and/or modify it under
 the terms of the Artistic License version 2.0.

--- a/lib/Mad/Mapper/Guides/Tutorial.pod
+++ b/lib/Mad/Mapper/Guides/Tutorial.pod
@@ -62,8 +62,8 @@ can also use L<Mojo::SQLite> or L<Mojo::mysql>.
       },
       sub {
         my ($delay, $err) = @_;
-        return $self->render_exception($err) if $err;
-        return $self->render(user => $user);
+        return $c->render_exception($err) if $err;
+        return $c->render(user => $user);
       },
     );
   };
@@ -76,13 +76,13 @@ can also use L<Mojo::SQLite> or L<Mojo::mysql>.
     $c->delay(
       sub {
         my ($delay) = @_;
-        $user->email($self->param("email"));
+        $user->email($c->param("email"));
         $user->save($delay->begin);
       },
       sub {
         my ($delay, $err) = @_;
-        return $self->render_exception($err) if $err;
-        return $self->render(user => $user);
+        return $c->render_exception($err) if $err;
+        return $c->render(user => $user);
       },
     );
   };


### PR DESCRIPTION
In addition to the fix typo requests, I have some questions that might help improve the documentation:

---

In the Synopsis, you state:

> The synopsis is split into three parts: The two first is for model developers, and the last is for the developer using the models.

There is a section header titled "Synopsis" so I would think that the 3 parts you're referring to are in this very small Synopsis, but I don't think that's the case.  If it's referring to 3 parts within the whole document, perhaps it could be reworded to "This documentation is split into three parts:" and if that is the case then I'm not sure where the three parts are.  Could you add markers to signify the three parts?

If you help me to understand the 3 sections, I'd be happy to apply the clarity through a PR.

---

For the table, you state:

> Used to define a table name. The default is to decamelize the last part of the class name and add "s" at the end, unless it already has "s" at the end.

Perhaps you could use Lingua::EN::Inflect to do this properly, for example with an example of App::Model::Box -> boxes instead of boxs?  Perhaps you could even do this only if Lingua::EN::Inflect is installed so as to not make that module a strict requirement?  However, that would be a bad idea because the code would expect boxes because the developer had the module installed but the user wouldn't have it installed and need boxs.  Perhaps setting a Mad::Mapper attribute of "proper_plural" to true would turn on this feature for the developer and then therefore require the module?

If you're interested in this I'd be willing to issue a pull request for this.  I think I could handle it completely on my own, but I'd be interested to know what you'd like to name the attribute.  Or if you'd have other ideas about how to go about this.

---

You refer often to "sst".  What does this mean?  Could you define it somewhere in the docs?  If you let me know, I'd be willing to find a place for it.