### PR TITLE
change the way in which we determine plural forms

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl distribution Mad-Mapper
 
+0.08 Not Released
+ - BREAKING CHANGE: use Lingua::EN::Inflect::Number to convert to plurals
+
 0.07 2015-12-04T14:11:09+0100
  - Using decamelize for table guessing #2
    Contributor: Krasimir Berov

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
 # You can install this projct with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/mad-mapper/archive/master.tar.gz
 requires "Mojolicious" => "5.40";
+requires "Lingua::EN::Inflect::Number" => "1.10";
 test_requires "Test::More" => "0.88";

--- a/lib/Mad/Mapper.pm
+++ b/lib/Mad/Mapper.pm
@@ -49,6 +49,7 @@ use Mojo::JSON ();
 use Mojo::Loader 'load_class';
 use Scalar::Util 'weaken';
 use constant DEBUG => $ENV{MAD_DEBUG} || 0;
+use Lingua::EN::Inflect::Number 'to_PL';
 
 our $VERSION = '0.07';
 
@@ -80,17 +81,21 @@ Note that L</pk> is not returned by L</columns>.
 =head2 table
 
 Used to define a table name. The default is to decamelize the last part of the
-class name and add "s" at the end, unless it already has "s" at the end.
-Examples:
+class name and make it plural using L<Lingua::EN::Inflect::Number>, note that
+due to the severe complexity of the English language, this can fail in
+spectacular ways. Examples:
 
-  .-------------------------------------.
-  | Class name            | table       |
-  |-----------------------|-------------|
-  | App::Model::User      | users       |
-  | App::Model::Users     | users       |
-  | App::Model::Group     | groups      |
-  | App::Model::UserAgent | user_agents |
-  '-------------------------------------'
+  .--------------------------------------------.
+  | Class name                | table          |
+  |---------------------------|----------------|
+  | App::Model::User          | users          |
+  | App::Model::Users         | users          |
+  | App::Model::Group         | groups         |
+  | App::Model::MyInventory   | my_inventories |
+  | App::Model::MyInventories | my_inventories |
+  | App::Model::Menu          | menus          |
+  | App::Model::Menus         | menuses (DOH!) |
+  '--------------------------------------------'
 
 =head1 ATTRIBUTES
 
@@ -251,8 +256,7 @@ sub import {
 
   if ($flag) {
     my $caller = caller;
-    my $table = Mojo::Util::decamelize((split /::/, $caller)[-1]);
-    $table =~ s!s?$!s!;    # user => users
+    my $table = to_PL(Mojo::Util::decamelize((split /::/, $caller)[-1]));
     Mojo::Util::monkey_patch($caller, col      => sub { $caller->_define_col(@_) });
     Mojo::Util::monkey_patch($caller, columns  => sub { @{$COLUMNS{$caller} || []} });
     Mojo::Util::monkey_patch($caller, has      => sub { Mojo::Base::attr($caller, @_) });

--- a/t/schema.t
+++ b/t/schema.t
@@ -28,14 +28,48 @@ is $user->forename('Lucy'), $user, 'forename';
 is $user->email, 'lucy@doe.com', 'email';
 is_deeply($user->TO_JSON, {id => undef, forename => 'Lucy', surname => 'Doe', email => 'lucy@doe.com'}, 'TO_JSON');
 
+# Test plural form of singular table
 eval <<'HERE' or die $@;
-package Model::UserAgent;
+package Model::MyInventory;
 use Mad::Mapper -base;
 pk 'id';
 1;
 HERE
 
-ok(Model::UserAgent->can($_), "UserAgent can $_") for (qw( id table ));
-is(Model::UserAgent->new->table, 'user_agents','class decamelized to table');
+ok(Model::MyInventory->can($_), "MyInventory can $_") for (qw( id table ));
+is(Model::MyInventory->new->table, 'my_inventories','class decamelized to table');
+
+# Test plural form of singular table when already plural
+eval <<'HERE' or die $@;
+package Model::MyInventories;
+use Mad::Mapper -base;
+pk 'id';
+1;
+HERE
+
+ok(Model::MyInventories->can($_), "MyInventories can $_") for (qw( id table ));
+is(Model::MyInventories->new->table, 'my_inventories','class decamelized to table');
+
+# Test plural form of singular table
+eval <<'HERE' or die $@;
+package Model::Menu;
+use Mad::Mapper -base;
+pk 'id';
+1;
+HERE
+
+ok(Model::Menu->can($_), "Menu can $_") for (qw( id table ));
+is(Model::Menu->new->table, 'menus','class decamelized to table');
+
+# Lingua:EN::Inflect::Number fails in some very spectacular ways: menuses???
+eval <<'HERE' or die $@;
+package Model::Menus;
+use Mad::Mapper -base;
+pk 'id';
+1;
+HERE
+
+ok(Model::Menus->can($_), "Menus can $_") for (qw( id table ));
+is(Model::Menus->new->table, 'menuses','class decamelized to table');
 
 done_testing;


### PR DESCRIPTION
Lingua::EN::Inflect's PL() seems to toggle the plural form.  I have used Lingua::EN::Inflect::Number instead, which can force to plural.  However, it's not without its problems.

Specifically see the table in Mapper.pm#84.

It seems that while this fails, it'll fail less frequently than just simply appending an s wherever there is no ending s.  However, that method is at least predictable.  A user can just know to add an s without first testing.  Using Lingua::EN::Inflect::Number, one wouldn't be able to guess at its failures and would need to adjust usages of menus to menuses after a run time error if the module is already the plural Menus.

So, we have a lose-lose situation here.  How complex!

  1. Don't use proper pluralization, or
  1. Use proper pluralization with less frequent, but unpredictable, failures